### PR TITLE
deal with non-connecred RX pin and allow test without Publishing to MQTT

### DIFF
--- a/source/publisher_task.c
+++ b/source/publisher_task.c
@@ -140,6 +140,7 @@ void publisher_task(void *pvParameters)
 
 
     	  for( ;; ) {
+
     	    if(xQueueReceive(telemetry_queue, message, portMAX_DELAY ))     {
     	      cyhal_gpio_toggle(CYBSP_USER_LED);
 
@@ -149,6 +150,9 @@ void publisher_task(void *pvParameters)
     	      printf("Publishing '%s' on the topic '%s'\n\n",
     	    		  (char *)publishInfo.pPayload,
 					  publishInfo.pTopicName);
+
+
+//    	      break; // todo: remove, this is to avoid spending messages
 
     	      /* Publish the MQTT message with the configured settings. */
     	      result = IotMqtt_PublishSync(mqttConnection,

--- a/source/uart_task.c
+++ b/source/uart_task.c
@@ -135,7 +135,9 @@ void initUART() {
   Cy_GPIO_SetHSIOM(UART_PORT, UART_RX_NUM, UART_RX_PIN);
   Cy_GPIO_SetHSIOM(UART_PORT, UART_TX_NUM, UART_TX_PIN);
   /* Configure pins for UART operation */
-  Cy_GPIO_SetDrivemode(UART_PORT, UART_RX_NUM, CY_GPIO_DM_HIGHZ);
+  // jc: HIGHZ is correct for UART. But in the design here, the input is "patch-wired" to another controller.
+  // Cy_GPIO_SetDrivemode(UART_PORT, UART_RX_NUM, CY_GPIO_DM_HIGHZ);
+  Cy_GPIO_SetDrivemode(UART_PORT, UART_RX_NUM, CY_GPIO_DM_PULLUP);
   Cy_GPIO_SetDrivemode(UART_PORT, UART_TX_NUM, CY_GPIO_DM_STRONG_IN_OFF);
 
   /* Assign divider type and number for UART */


### PR DESCRIPTION
Normally, RX is high impedance. In this design, where the input device
TX pin is connected via wires and may be switched on / off / resetted,
it will create random UART noise.
I put the RX to CY_GPIO_DM_PULLUP.

I also added a break just before the MQTT Send, commented out.
If you uncomment it, you can test the device without generating traffic
-> May save on the AWS bill.