### PR TITLE
code style cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The project software and components
 
 
 ## Documentation
-- [NonoDrone II workshop](https://www.element14.com/community/events/5782/l/arduino-day-workshop-nanodrone-ii-ai-and-computer-vision-with-lora-win-a-psoc6-and-a-pair-of-mkr-1300-boards)
+- [NanoDrone II workshop](https://www.element14.com/community/events/5782/l/arduino-day-workshop-nanodrone-ii-ai-and-computer-vision-with-lora-win-a-psoc6-and-a-pair-of-mkr-1300-boards)
 - [PSoC6 firmware documentation series](https://www.element14.com/community/groups/embedded/blog/2021/03/13/psoc6-and-modustoolbox-uart-receiver-with-freertos)
 
 

--- a/source/main.c
+++ b/source/main.c
@@ -86,6 +86,8 @@ int main()
     /* To avoid compiler warnings. */
     (void) result;
 
+    cyhal_gpio_init(CYBSP_USER_LED, CYHAL_GPIO_DIR_OUTPUT, CYHAL_GPIO_DRIVE_PULLUP,
+                    CYBSP_LED_STATE_OFF);
 
     initUART();
 

--- a/source/publisher_task.c
+++ b/source/publisher_task.c
@@ -1,45 +1,45 @@
 /******************************************************************************
-* File Name:   publisher_task.c
-*
-* Description: This file contains the task that initializes the user button
-*              GPIO, configures the ISR, and publishes MQTT messages on the 
-*              topic 'MQTT_TOPIC_NANODRONE' to control a device that is actuated by the
-*              subscriber task. The file also contains the ISR that notifies
-*              the publisher task about the new device state to be published.
-*
-* Related Document: See README.md
-*
-*******************************************************************************
-* (c) 2020-2021, Cypress Semiconductor Corporation. All rights reserved.
-*******************************************************************************
-* This software, including source code, documentation and related materials
-* ("Software"), is owned by Cypress Semiconductor Corporation or one of its
-* subsidiaries ("Cypress") and is protected by and subject to worldwide patent
-* protection (United States and foreign), United States copyright laws and
-* international treaty provisions. Therefore, you may use this Software only
-* as provided in the license agreement accompanying the software package from
-* which you obtained this Software ("EULA").
-*
-* If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
-* non-transferable license to copy, modify, and compile the Software source
-* code solely for use in connection with Cypress's integrated circuit products.
-* Any reproduction, modification, translation, compilation, or representation
-* of this Software except as specified above is prohibited without the express
-* written permission of Cypress.
-*
-* Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
-* reserves the right to make changes to the Software without notice. Cypress
-* does not assume any liability arising out of the application or use of the
-* Software or any product or circuit described in the Software. Cypress does
-* not authorize its products for use in any products where a malfunction or
-* failure of the Cypress product may reasonably be expected to result in
-* significant property damage, injury or death ("High Risk Product"). By
-* including Cypress's product in a High Risk Product, the manufacturer of such
-* system or application assumes all risk of such use and in doing so agrees to
-* indemnify Cypress against all liability.
-*******************************************************************************/
+ * File Name:   publisher_task.c
+ *
+ * Description: This file contains the task that initializes the user button
+ *              GPIO, configures the ISR, and publishes MQTT messages on the
+ *              topic 'MQTT_TOPIC_NANODRONE' to control a device that is actuated by the
+ *              subscriber task. The file also contains the ISR that notifies
+ *              the publisher task about the new device state to be published.
+ *
+ * Related Document: See README.md
+ *
+ *******************************************************************************
+ * (c) 2020-2021, Cypress Semiconductor Corporation. All rights reserved.
+ *******************************************************************************
+ * This software, including source code, documentation and related materials
+ * ("Software"), is owned by Cypress Semiconductor Corporation or one of its
+ * subsidiaries ("Cypress") and is protected by and subject to worldwide patent
+ * protection (United States and foreign), United States copyright laws and
+ * international treaty provisions. Therefore, you may use this Software only
+ * as provided in the license agreement accompanying the software package from
+ * which you obtained this Software ("EULA").
+ *
+ * If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
+ * non-transferable license to copy, modify, and compile the Software source
+ * code solely for use in connection with Cypress's integrated circuit products.
+ * Any reproduction, modification, translation, compilation, or representation
+ * of this Software except as specified above is prohibited without the express
+ * written permission of Cypress.
+ *
+ * Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
+ * reserves the right to make changes to the Software without notice. Cypress
+ * does not assume any liability arising out of the application or use of the
+ * Software or any product or circuit described in the Software. Cypress does
+ * not authorize its products for use in any products where a malfunction or
+ * failure of the Cypress product may reasonably be expected to result in
+ * significant property damage, injury or death ("High Risk Product"). By
+ * including Cypress's product in a High Risk Product, the manufacturer of such
+ * system or application assumes all risk of such use and in doing so agrees to
+ * indemnify Cypress against all liability.
+ *******************************************************************************/
 
 #include "cyhal.h"
 #include "cybsp.h"
@@ -58,17 +58,12 @@
 #include "cy_retarget_io.h"
 #include "iot_mqtt.h"
 
-
 #include "telemetry_queue.h"
 #include <string.h>
 
-
-
-
-
 /******************************************************************************
-* Macros
-******************************************************************************/
+ * Macros
+ ******************************************************************************/
 /* The maximum number of times each PUBLISH in this example will be retried. */
 #define PUBLISH_RETRY_LIMIT             (10)
 
@@ -78,25 +73,20 @@
 #define PUBLISH_RETRY_MS                (1000)
 
 /******************************************************************************
-* Global Variables
-*******************************************************************************/
+ * Global Variables
+ *******************************************************************************/
 /* FreeRTOS task handle for this task. */
 TaskHandle_t publisher_task_handle;
 
 /* Structure to store publish message information. */
-IotMqttPublishInfo_t publishInfo =
-{
-    .qos = (IotMqttQos_t) MQTT_MESSAGES_QOS,
-    .pTopicName = MQTT_TOPIC_NANODRONE,
-    .topicNameLength = (sizeof(MQTT_TOPIC_NANODRONE) - 1),
-    .retryMs = PUBLISH_RETRY_MS,
-    .retryLimit = PUBLISH_RETRY_LIMIT
-};
+IotMqttPublishInfo_t publishInfo = { .qos = (IotMqttQos_t) MQTT_MESSAGES_QOS,
+        .pTopicName = MQTT_TOPIC_NANODRONE, .topicNameLength =
+                (sizeof(MQTT_TOPIC_NANODRONE) - 1), .retryMs = PUBLISH_RETRY_MS,
+        .retryLimit = PUBLISH_RETRY_LIMIT };
 
 extern QueueHandle_t telemetry_queue;
 
 uint8_t message[TELEMETRY_MESSAGE_SIZE];
-
 
 /******************************************************************************
  * Function Name: publisher_task
@@ -113,8 +103,7 @@ uint8_t message[TELEMETRY_MESSAGE_SIZE];
  *  void
  *
  ******************************************************************************/
-void publisher_task(void *pvParameters)
-{
+void publisher_task(void *pvParameters) {
     /* Status variable */
     int result;
 
@@ -124,57 +113,37 @@ void publisher_task(void *pvParameters)
     mqtt_result_t mqtt_publish_status = MQTT_PUBLISH_FAILURE;
 
     /* To avoid compiler warnings */
-    (void)pvParameters;
+    (void) pvParameters;
 
     initTelemetryQueue();
     printf("TELEMETRY Message Queue created\n\n");
 
+    for (;;) {
+        if (xQueueReceive(telemetry_queue, message, portMAX_DELAY)) {
+            cyhal_gpio_toggle(CYBSP_USER_LED);
 
+            publishInfo.pPayload = message;
+            publishInfo.payloadLength = sizeof(message);
+            ;
 
-    while (true)
-    {
+            printf("Publishing '%s' on the topic '%s'\n\n",
+                    (char*) publishInfo.pPayload, publishInfo.pTopicName);
 
+            /* Publish the MQTT message with the configured settings. */
+            result = IotMqtt_PublishSync(mqttConnection, &publishInfo, 0,
+            MQTT_TIMEOUT_MS);
 
-    	  for( ;; ) {
-
-    	    if(xQueueReceive(telemetry_queue, message, portMAX_DELAY ))     {
-    	      cyhal_gpio_toggle(CYBSP_USER_LED);
-
-    	      publishInfo.pPayload = message;
-    	      publishInfo.payloadLength = sizeof(message);;
-
-    	      printf("Publishing '%s' on the topic '%s'\n\n",
-    	    		  (char *)publishInfo.pPayload,
-					  publishInfo.pTopicName);
-
-
-//    	      break; // todo: remove, this is to avoid spending messages
-
-    	      /* Publish the MQTT message with the configured settings. */
-    	      result = IotMqtt_PublishSync(mqttConnection,
-    	    		  &publishInfo,
-					  0,
-					  MQTT_TIMEOUT_MS);
-
-    	      if (result != IOT_MQTT_SUCCESS)
-    	      {
-    	    	  /* Inform the MQTT client task about the publish failure and suspend
-    	    	   * the task for it to be killed by the MQTT client task later.
-    	    	   */
-    	    	  printf("MQTT Publish failed with error '%s'.\n\n",
-    	    			  IotMqtt_strerror((IotMqttError_t) result));
-    	    	  xQueueOverwrite(mqtt_status_q, &mqtt_publish_status);
-    	    	  vTaskSuspend( NULL );
-    	      }
-
-    	      cyhal_gpio_toggle(CYBSP_USER_LED);
-
-
-    	    }
-
-    	  } // end for
-
-
+            if (result != IOT_MQTT_SUCCESS) {
+                /* Inform the MQTT client task about the publish failure and suspend
+                 * the task for it to be killed by the MQTT client task later.
+                 */
+                printf("MQTT Publish failed with error '%s'.\n\n",
+                        IotMqtt_strerror((IotMqttError_t) result));
+                xQueueOverwrite(mqtt_status_q, &mqtt_publish_status);
+                vTaskSuspend( NULL);
+            }
+            cyhal_gpio_toggle(CYBSP_USER_LED);
+        }
     }
 }
 
@@ -191,8 +160,7 @@ void publisher_task(void *pvParameters)
  *  void
  *
  ******************************************************************************/
-void publisher_cleanup(void)
-{
+void publisher_cleanup(void) {
 }
 
 /* [] END OF FILE */

--- a/source/publisher_task.c
+++ b/source/publisher_task.c
@@ -126,10 +126,6 @@ void publisher_task(void *pvParameters)
     /* To avoid compiler warnings */
     (void)pvParameters;
 
-    cyhal_gpio_init(CYBSP_USER_LED, CYHAL_GPIO_DIR_OUTPUT, CYHAL_GPIO_DRIVE_PULLUP,
-                    CYBSP_LED_STATE_OFF);
-
-
     initTelemetryQueue();
     printf("TELEMETRY Message Queue created\n\n");
 

--- a/source/publisher_task.c
+++ b/source/publisher_task.c
@@ -118,7 +118,7 @@ void publisher_task(void *pvParameters) {
     initTelemetryQueue();
     printf("TELEMETRY Message Queue created\n\n");
 
-    for (;;) {
+    while (true) {
         if (xQueueReceive(telemetry_queue, message, portMAX_DELAY)) {
             cyhal_gpio_toggle(CYBSP_USER_LED);
 

--- a/source/uart_task.c
+++ b/source/uart_task.c
@@ -21,7 +21,7 @@
 /* Allocate context for UART operation */
 cy_stc_scb_uart_context_t uartContext;
 /* Stores the handle of the task that will be notified when the
-transmission is complete. */
+receive is complete. */
 volatile TaskHandle_t xTaskToNotify_UART;
 
 /* The index within the target task's array of task notifications
@@ -195,10 +195,10 @@ void UART_Isr() {
 		xTaskToNotify_UART = NULL;
 
 		/* If xHigherPriorityTaskWoken is now set to pdTRUE then a
-  context switch should be performed to ensure the interrupt
-  returns directly to the highest priority task.  The macro used
-  for this purpose is dependent on the port in use and may be
-  called portEND_SWITCHING_ISR(). */
+		context switch should be performed to ensure the interrupt
+		returns directly to the highest priority task.  The macro used
+		for this purpose is dependent on the port in use and may be
+		called portEND_SWITCHING_ISR(). */
 		portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 	}
 }

--- a/source/uart_task.c
+++ b/source/uart_task.c
@@ -21,13 +21,12 @@
 /* Allocate context for UART operation */
 cy_stc_scb_uart_context_t uartContext;
 /* Stores the handle of the task that will be notified when the
-receive is complete. */
+ receive is complete. */
 volatile TaskHandle_t xTaskToNotify_UART;
 
 /* The index within the target task's array of task notifications
-to use. */
+ to use. */
 const UBaseType_t xArrayIndex = 1;
-
 
 uint8_t rxBuffer[UART_BUFFER_SIZE];
 
@@ -37,24 +36,15 @@ cy_stc_scb_uart_context_t uartContext;
 void UART_receive();
 
 // low power support
-cy_stc_syspm_callback_params_t callback_params =
-{
-    .base = UART_SCB,
-    .context = &uartContext
-};
+cy_stc_syspm_callback_params_t callback_params = { .base = UART_SCB, .context =
+        &uartContext };
 
-cy_stc_syspm_callback_t uart_deep_sleep_cb =
-{
-    Cy_SCB_UART_DeepSleepCallback,
-    CY_SYSPM_DEEPSLEEP,
-	0,
-    &callback_params,
-	NULL,
-	NULL
-};
+cy_stc_syspm_callback_t uart_deep_sleep_cb = { Cy_SCB_UART_DeepSleepCallback,
+        CY_SYSPM_DEEPSLEEP, 0, &callback_params,
+        NULL,
+        NULL };
 
 extern QueueHandle_t telemetry_queue;
-
 
 /******************************************************************************
  * Function Name: uart_task
@@ -71,149 +61,135 @@ extern QueueHandle_t telemetry_queue;
  ******************************************************************************/
 void uart_task(void *pvParameters) {
 
-  /* To avoid compiler warnings */
-  (void)pvParameters;
-  uint32_t ulNotificationValue;
-  xTaskToNotify_UART = NULL;
+    /* To avoid compiler warnings */
+    (void) pvParameters;
+    uint32_t ulNotificationValue;
+    xTaskToNotify_UART = NULL;
 
-  while (true) {
+    while (true) {
 
-    /* Start the receiving from UART. */
-    UART_receive();
-    /* Wait to be notified that the receive is complete.  Note
-        the first parameter is pdTRUE, which has the effect of clearing
-        the task's notification value back to 0, making the notification
-        value act like a binary (rather than a counting) semaphore.  */
-    ulNotificationValue = ulTaskNotifyTake(pdTRUE, portMAX_DELAY  );
+        /* Start the receiving from UART. */
+        UART_receive();
+        /* Wait to be notified that the receive is complete.  Note
+         the first parameter is pdTRUE, which has the effect of clearing
+         the task's notification value back to 0, making the notification
+         value act like a binary (rather than a counting) semaphore.  */
+        ulNotificationValue = ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 
+        if (ulNotificationValue == 1) {
+            /* Blocking wait until buffer is full */
+            // in this example, it will never handle because the UART interrupt fires exaxtly when the buffer is full
+            while (0UL
+                    != (CY_SCB_UART_RECEIVE_ACTIVE
+                            & Cy_SCB_UART_GetReceiveStatus(UART_SCB,
+                                    &uartContext))) {
+            }
+            /* Handle received data */
 
-    if( ulNotificationValue == 1 )
-    {
-      /* Blocking wait until buffer is full */
-      // in this example, it will never handle because the UART interrupt fires exaxtly when the buffer is full
-      while (0UL != (CY_SCB_UART_RECEIVE_ACTIVE & Cy_SCB_UART_GetReceiveStatus(UART_SCB, &uartContext))) {}
-      /* Handle received data */
+            if (telemetry_queue) { // queue needs to be generated}
+                if ( xQueueSend( telemetry_queue,
+                        ( void * ) rxBuffer,
+                        ( TickType_t ) 10 ) != pdPASS) {
+                    /* Failed to post the message, even after 10 ticks. */
+                    CY_ASSERT_L3(!0);
+                }
+            }
 
-      if(telemetry_queue) { // queue needs to be generated}
-        if( xQueueSend( telemetry_queue,
-                       ( void * ) rxBuffer,
-                       ( TickType_t ) 10 ) != pdPASS )
-        {
-            /* Failed to post the message, even after 10 ticks. */
-          CY_ASSERT_L3(!0);
         }
-      }
-
     }
-  }
 }
 
 void initUART() {
-  // https://cypresssemiconductorco.github.io/psoc6pdl/pdl_api_reference_manual/html/group__group__scb__uart.html
+    // https://cypresssemiconductorco.github.io/psoc6pdl/pdl_api_reference_manual/html/group__group__scb__uart.html
 
+    /* Populate configuration structure */
+    const cy_stc_scb_uart_config_t uartConfig = { .uartMode =
+            CY_SCB_UART_STANDARD, .enableMutliProcessorMode = false,
+            .smartCardRetryOnNack = false, .irdaInvertRx = false,
+            .irdaEnableLowPowerReceiver = false, .oversample = UART_OVERSAMPLE,
+            .enableMsbFirst = false, .dataWidth = 8UL, .parity =
+                    CY_SCB_UART_PARITY_NONE,
+            .stopBits = CY_SCB_UART_STOP_BITS_1, .enableInputFilter = false,
+            .breakWidth = 11UL, .dropOnFrameError = false, .dropOnParityError =
+                    false, .receiverAddress = 0UL, .receiverAddressMask = 0UL,
+            .acceptAddrInFifo = false, .enableCts = false, .ctsPolarity =
+                    CY_SCB_UART_ACTIVE_LOW, .rtsRxFifoLevel = 0UL,
+            .rtsPolarity = CY_SCB_UART_ACTIVE_LOW, .rxFifoTriggerLevel = 0UL,
+            .rxFifoIntEnableMask = 0UL, .txFifoTriggerLevel = 0UL,
+            .txFifoIntEnableMask = 0UL, };
+    /* Configure UART to operate */
+    (void) Cy_SCB_UART_Init(UART_SCB, &uartConfig, &uartContext);
 
-  /* Populate configuration structure */
-  const cy_stc_scb_uart_config_t uartConfig = {
-      .uartMode                   = CY_SCB_UART_STANDARD,
-      .enableMutliProcessorMode   = false,
-      .smartCardRetryOnNack       = false,
-      .irdaInvertRx               = false,
-      .irdaEnableLowPowerReceiver = false,
-      .oversample                 = UART_OVERSAMPLE,
-      .enableMsbFirst             = false,
-      .dataWidth                  = 8UL,
-      .parity                     = CY_SCB_UART_PARITY_NONE,
-      .stopBits                   = CY_SCB_UART_STOP_BITS_1,
-      .enableInputFilter          = false,
-      .breakWidth                 = 11UL,
-      .dropOnFrameError           = false,
-      .dropOnParityError          = false,
-      .receiverAddress            = 0UL,
-      .receiverAddressMask        = 0UL,
-      .acceptAddrInFifo           = false,
-      .enableCts                  = false,
-      .ctsPolarity                = CY_SCB_UART_ACTIVE_LOW,
-      .rtsRxFifoLevel             = 0UL,
-      .rtsPolarity                = CY_SCB_UART_ACTIVE_LOW,
-      .rxFifoTriggerLevel  = 0UL,
-      .rxFifoIntEnableMask = 0UL,
-      .txFifoTriggerLevel  = 0UL,
-      .txFifoIntEnableMask = 0UL,
-  };
-  /* Configure UART to operate */
-  (void) Cy_SCB_UART_Init(UART_SCB, &uartConfig, &uartContext);
+    /* Assign pins for UART on SCBx */
 
-  /* Assign pins for UART on SCBx */
+    /* Connect SCB UART function to pins */
+    Cy_GPIO_SetHSIOM(UART_PORT, UART_RX_NUM, UART_RX_PIN);
+    Cy_GPIO_SetHSIOM(UART_PORT, UART_TX_NUM, UART_TX_PIN);
+    /* Configure pins for UART operation */
+    // jc: HIGHZ is correct for UART. But in the design here, the input is "patch-wired" to another controller.
+    // Cy_GPIO_SetDrivemode(UART_PORT, UART_RX_NUM, CY_GPIO_DM_HIGHZ);
+    Cy_GPIO_SetDrivemode(UART_PORT, UART_RX_NUM, CY_GPIO_DM_PULLUP);
+    Cy_GPIO_SetDrivemode(UART_PORT, UART_TX_NUM, CY_GPIO_DM_STRONG_IN_OFF);
 
-  /* Connect SCB UART function to pins */
-  Cy_GPIO_SetHSIOM(UART_PORT, UART_RX_NUM, UART_RX_PIN);
-  Cy_GPIO_SetHSIOM(UART_PORT, UART_TX_NUM, UART_TX_PIN);
-  /* Configure pins for UART operation */
-  // jc: HIGHZ is correct for UART. But in the design here, the input is "patch-wired" to another controller.
-  // Cy_GPIO_SetDrivemode(UART_PORT, UART_RX_NUM, CY_GPIO_DM_HIGHZ);
-  Cy_GPIO_SetDrivemode(UART_PORT, UART_RX_NUM, CY_GPIO_DM_PULLUP);
-  Cy_GPIO_SetDrivemode(UART_PORT, UART_TX_NUM, CY_GPIO_DM_STRONG_IN_OFF);
+    /* Assign divider type and number for UART */
 
-  /* Assign divider type and number for UART */
+    /* Connect assigned divider to be a clock source for UART */
+    Cy_SysClk_PeriphAssignDivider(UART_CLOCK, UART_CLK_DIV_TYPE,
+            UART_CLK_DIV_NUMBER);
 
-  /* Connect assigned divider to be a clock source for UART */
-  Cy_SysClk_PeriphAssignDivider(UART_CLOCK, UART_CLK_DIV_TYPE, UART_CLK_DIV_NUMBER);
+    // set baud
+    Cy_SysClk_PeriphSetDivider(UART_CLK_DIV_TYPE, UART_CLK_DIV_NUMBER,
+            UART_DIVISION);
+    Cy_SysClk_PeriphEnableDivider(UART_CLK_DIV_TYPE, UART_CLK_DIV_NUMBER);
 
+    /* Populate configuration structure (code specific for CM4) */
+    cy_stc_sysint_t uartIntrConfig = { .intrSrc = UART_INTR_NUM, .intrPriority =
+            UART_INTR_PRIORITY, };
+    /* Hook interrupt service routine and enable interrupt */
+    (void) Cy_SysInt_Init(&uartIntrConfig, &UART_Isr);
+    NVIC_EnableIRQ(UART_INTR_NUM);
 
-  // set baud
-  Cy_SysClk_PeriphSetDivider   (UART_CLK_DIV_TYPE, UART_CLK_DIV_NUMBER, UART_DIVISION);
-  Cy_SysClk_PeriphEnableDivider(UART_CLK_DIV_TYPE, UART_CLK_DIV_NUMBER);
+    /* Register a deep sleep callback for UART block. */
+    Cy_SysPm_RegisterCallback(&uart_deep_sleep_cb);
 
-  /* Populate configuration structure (code specific for CM4) */
-  cy_stc_sysint_t uartIntrConfig =
-  {
-      .intrSrc      = UART_INTR_NUM,
-      .intrPriority = UART_INTR_PRIORITY,
-  };
-  /* Hook interrupt service routine and enable interrupt */
-  (void) Cy_SysInt_Init(&uartIntrConfig, &UART_Isr);
-  NVIC_EnableIRQ(UART_INTR_NUM);
-
-  /* Register a deep sleep callback for UART block. */
-  Cy_SysPm_RegisterCallback(&uart_deep_sleep_cb);
-
-  /* Enable UART to operate */
-  Cy_SCB_UART_Enable(UART_SCB);
+    /* Enable UART to operate */
+    Cy_SCB_UART_Enable(UART_SCB);
 }
 
 // UART interrupt handler
 void UART_Isr() {
-	Cy_SCB_UART_Interrupt(UART_SCB, &uartContext);
+    Cy_SCB_UART_Interrupt(UART_SCB, &uartContext);
 
-	BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	if( xTaskToNotify_UART != NULL ) {
+    if (xTaskToNotify_UART != NULL) {
 
-		/* Notify the task that the receive is complete. */
-		vTaskNotifyGiveFromISR( xTaskToNotify_UART, &xHigherPriorityTaskWoken );
-		/* There are no receive in progress, so no tasks to notify. */
-		xTaskToNotify_UART = NULL;
+        /* Notify the task that the receive is complete. */
+        vTaskNotifyGiveFromISR(xTaskToNotify_UART, &xHigherPriorityTaskWoken);
+        /* There are no receive in progress, so no tasks to notify. */
+        xTaskToNotify_UART = NULL;
 
-		/* If xHigherPriorityTaskWoken is now set to pdTRUE then a
-		context switch should be performed to ensure the interrupt
-		returns directly to the highest priority task.  The macro used
-		for this purpose is dependent on the port in use and may be
-		called portEND_SWITCHING_ISR(). */
-		portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-	}
+        /* If xHigherPriorityTaskWoken is now set to pdTRUE then a
+         context switch should be performed to ensure the interrupt
+         returns directly to the highest priority task.  The macro used
+         for this purpose is dependent on the port in use and may be
+         called portEND_SWITCHING_ISR(). */
+        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    }
 }
 
 // UART activate a receive with interrupt. Wait for ever for UART_BUFFER_SIZE bytes
 void UART_receive() {
-  /* At this point xTaskToNotify should be NULL as no receive
-  is in progress.  A mutex can be used to guard access to the
-  peripheral if necessary. */
-  configASSERT( xTaskToNotify_UART == NULL );
+    /* At this point xTaskToNotify should be NULL as no receive
+     is in progress.  A mutex can be used to guard access to the
+     peripheral if necessary. */
+    configASSERT(xTaskToNotify_UART == NULL);
 
-  /* Store the handle of the calling task. */
-  xTaskToNotify_UART = xTaskGetCurrentTaskHandle();
+    /* Store the handle of the calling task. */
+    xTaskToNotify_UART = xTaskGetCurrentTaskHandle();
 
-  /* Start receive operation (do not check status) */
-  (void) Cy_SCB_UART_Receive(UART_SCB, rxBuffer, sizeof(rxBuffer), &uartContext);
+    /* Start receive operation (do not check status) */
+    (void) Cy_SCB_UART_Receive(UART_SCB, rxBuffer, sizeof(rxBuffer),
+            &uartContext);
 }
 


### PR DESCRIPTION
consistency in source file formatting
4 spaces instead of TABs (better when pasting code in a blog)
There was a mix of for(;;) and while(true) loops. Settled for while(true) because also used by AWT